### PR TITLE
Remove host request install validation as "*" does not reliably work

### DIFF
--- a/lib/middleware/verify-installation.js
+++ b/lib/middleware/verify-installation.js
@@ -32,14 +32,17 @@ function verifyInstallation(addon) {
             return;
         }
 
-        var host = urls.parse(baseUrl).hostname;
-        var whitelisted = addon.config.whitelistRegexp().some(function (re) {
-            return re.test(host);
-        });
-        if (!whitelisted) {
-            return sendError('Host at ' + baseUrl + ' is not authorized to register as the host does not match the ' +
-                'registration whitelist (' + addon.config.whitelist() + ').');
-        }
+        // disable whitelist until fix is realized
+        // add option to suppress as * (allow all hosts) does not
+        // reliably work for NODE_ENV=production (or fix regex logic)
+        //var host = urls.parse(baseUrl).hostname;
+        //var whitelisted = addon.config.whitelistRegexp().some(function (re) {
+            //return re.test(host);
+        //});
+        //if (!whitelisted) {
+            //return sendError('Host at ' + baseUrl + ' is not authorized to register as the host does not match the ' +
+                //'registration whitelist (' + addon.config.whitelist() + ').');
+        //}
 
         var clientKey = regInfo.clientKey;
         if (!clientKey) {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "atlassian-connect-express",
+  "name": "@qasymphony/atlassian-connect-express",
   "version": "2.1.4",
   "description": "Library for building Atlassian Add-ons on top of Express",
   "author": "Atlassian",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "http://bitbucket.org/atlassian/atlassian-connect-express"
+    "url": "https://github.com/QAS-Labs/atlassian-connect-express"
   },
-  "homepage": "https://bitbucket.org/atlassian/atlassian-connect-express",
+  "homepage": "https://github.com/QAS-Labs/atlassian-connect-express",
   "keywords": [
     "atlassian",
     "plugins",


### PR DESCRIPTION
TODO: provide option to suppress or determine root cause of why `*` does not work for `NODE_ENV=production` (not enough time right now to merge canonical fix upstream).